### PR TITLE
No empty activity in recent apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
             </intent-filter>
         </service>
 
-        <activity android:name=".LongPressReceiver">
+        <activity android:name=".LongPressReceiver"
+            android:excludeFromRecents="true">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES"/>
             </intent-filter>


### PR DESCRIPTION
Removes empty activity in recent apps after long press on the tile